### PR TITLE
Refactor main.py into smaller modules

### DIFF
--- a/image_utils.py
+++ b/image_utils.py
@@ -1,0 +1,19 @@
+import cv2
+import numpy as np
+from pdf2image import convert_from_bytes
+
+
+def preprocess_image(image):
+    """Apply preprocessing steps to improve OCR results."""
+    image = cv2.resize(image, None, fx=2, fy=2, interpolation=cv2.INTER_CUBIC)
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (2, 2))
+    image = cv2.morphologyEx(image, cv2.MORPH_OPEN, kernel)
+    image = cv2.convertScaleAbs(image, alpha=1.5, beta=0)
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    return image
+
+
+def convert_pdf_to_images(pdf_bytes):
+    """Convert a PDF file into a list of images."""
+    images = convert_from_bytes(pdf_bytes)
+    return [np.array(image) for image in images]

--- a/ocr_utils.py
+++ b/ocr_utils.py
@@ -1,0 +1,8 @@
+import pytesseract
+
+
+def extract_text(image, orientation_mode: bool = False) -> str:
+    """Run Tesseract OCR on the provided image."""
+    config = '--psm 6 --oem 3' if orientation_mode else '--psm 7'
+    text = pytesseract.image_to_string(image, lang='por', config=config).strip()
+    return text

--- a/validation.py
+++ b/validation.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from image_utils import preprocess_image
+from ocr_utils import extract_text
+
+
+KEYWORDS: List[str] = [
+    "PREFEITURA", "PRESTADOR", "TOMADOR", "VALOR",
+    "NOTA", "FISCAL", "CPF", "CNPJ",
+]
+
+
+def orientation_is_valid(image) -> bool:
+    """Check if the orientation of the NFS-e is correct based on keywords."""
+    img = preprocess_image(image)
+    text = extract_text(img, orientation_mode=True)
+    return any(keyword.lower() in text.lower() for keyword in KEYWORDS)


### PR DESCRIPTION
## Summary
- move image preprocessing and pdf conversion helpers to `image_utils.py`
- move OCR helper to `ocr_utils.py`
- move orientation validation to `validation.py`
- simplify `main.py` by importing these new helpers

## Testing
- `python -m py_compile main.py image_utils.py ocr_utils.py validation.py`
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68435f8a5e988327a5b96c6fc16def60